### PR TITLE
[0.1.0] - Inicio do projeto e da proposta.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Sistema operacional
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/
+*.code-workspace
+
+# Deno
+deno.lock
+deno.jsonc
+
+# Test snapshots, se um dia usar
+__snapshots__/
+
+# Logs
+*.log
+
+# Outros
+node_modules/  # só se alguém tentar usar sem saber que é Deno

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2025 Gabriel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell     
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:                      
+
+The above copyright notice and this permission notice shall be included in    
+all copies or substantial portions of the Software.                           
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR    
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,      
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE   
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER        
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN     
+THE SOFTWARE.
+
+---
+
+Se você leu até aqui: parabéns, você faz parte de 0.01% da internet.
+
+Agora, usa com carinho. Se encontrar bug, corrige e manda PR.  
+Se isso te ajudou, considera dar uma estrela no repositório.  
+Se você melhorar esse código, eu provavelmente vou te agradecer pra sempre.
+
+E não, não tem pegadinha. Só código sincero mesmo.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,104 @@
-# deno-sincerao
+# 🦖 deno-sincerao
+
+> Um tapa na cara do TypeScript em tempo de execução.  
+> Aqui é `string` de verdade, `number` que presta e `NaN` vai direto pro inferno.
+
+---
+
+## 💡 O que é isso?
+
+O `deno-sincerao` é a minha tentativa de fazer o que o TypeScript **deveria fazer em runtime, mas não faz**.  
+É uma função simples (por enquanto) que garante que valores são **realmente** do tipo que dizem ser.  
+Não aceitamos falsos `string`, `number` de mentira (`NaN`), nem aquele `undefined` sorrateiro que passa batido no `typeof`.
+
+Isso aqui nasceu da minha frustração ao perceber que o TS é firme... até o momento em que o código começa a rodar.  
+Aí ele vira o fiscal de segurança que deixa passar gente com mochila suspeita.
+
+---
+
+## 🤖 Por que eu fiz isso?
+
+Porque um dia, no meio da raiva com `new String()` sendo aceito como string, eu gritei:  
+**"NÃO, AGORA VOU FAZER DO MEU JEITO!"**
+
+A ideia nasceu comigo, **Gabriel**, mas teve o empurrão técnico do ChatGPT (sim, eu usei com gosto e sem vergonha).  
+Eu escrevi, revisei, coloquei meu veneno, e agora tô abrindo pro mundo.
+
+---
+
+## 🙏 Contribuições? POR FAVOR.
+
+Eu **não sou especialista em TypeScript**, mas eu sou teimoso.  
+Pretendo expandir isso com:
+
+- Mais validações refinadas
+- Suporte a tipos compostos e customizados
+- Um dia (quem sabe) **implementar um `guard let` igual ao do Swift**, com sintaxe própria e tudo
+
+Se você manja mais que eu, **mande PR**, **corrija** as bobagens e **me ajude a deixar isso melhor**.  
+E se você achar bug... **PELO AMOR DE DEUS, ARRUME**.
+
+---
+
+## 🚀 Instalação
+
+Importe direto do Deno.land (versão 1.0.0 como exemplo):
+
+```ts
+import { isReallyThisTypeOf, TYPES } from "https://deno.land/x/deno_sincerao@v1.0.0/mod.ts";
+```
+
+---
+
+## ✅ Uso
+
+```ts
+isReallyThisTypeOf("Gabriel", TYPES.STRING); // true
+isReallyThisTypeOf(new String("Gabriel"), TYPES.STRING); // false (isso aqui não cola)
+isReallyThisTypeOf(42, TYPES.NUMBER); // true
+isReallyThisTypeOf(NaN, TYPES.NUMBER); // false (vai embora)
+isReallyThisTypeOf(undefined, TYPES.STRING); // false
+```
+
+---
+
+## 🔎 Tipos suportados
+
+```ts
+enum TYPES {
+  STRING = 'string',
+  NUMBER = 'number',
+  BOOLEAN = 'boolean',
+  OBJECT = 'object',
+  FUNCTION = 'function',
+  SYMBOL = 'symbol',
+  BIGINT = 'bigint',
+}
+```
+
+Cada tipo passa por uma validação real, não só o `typeof`:
+
+- `STRING` → só strings primitivas, sem `new String()`, nem vazias ou com espaço
+- `NUMBER` → precisa ser `number` real, sem `NaN`, sem `Infinity`
+- `OBJECT` → só objetos simples, não arrays, nem `null`
+- E assim por diante...
+
+---
+
+## 😎 Filosofia por trás
+
+**TypeScript é útil. Mas não é perfeito.**  
+Em runtime, ele confia demais. Aqui, a confiança é conquistada — e testada.
+
+Esse projeto é pequeno, mas nasceu pra crescer.  
+E um dia, quem sabe, pode virar um mini framework de validações, ou pelo menos te salvar de bugs bestas.
+
+---
+
+## 🙌 Feito por Gabriel, com ajuda técnica do ChatGPT, e uma dose generosa de ódio ao `typeof`.
+
+---
+
+## 📄 Licença
+
+MIT — use, compartilhe, modifique, e se der bug, leia o código com carinho antes de xingar no Twitter.

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true
+  },
+  "lint": {
+    "include": ["src", "tests"],
+    "exclude": ["node_modules"]
+  },
+  "fmt": {
+    "include": ["src", "tests", "mod.ts"]
+  },
+  "tasks": {
+    "test": "deno test",
+    "lint": "deno lint",
+    "fmt": "deno fmt"
+  }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,5 @@
+// Exporta a função principal de validação
+export { isReallyThisTypeOf } from "./src/isReallyThisTypeOf.ts";
+
+// Exporta o enum de tipos aceitos
+export { TYPES } from "./src/types.ts";

--- a/src/isReallyThisTypeOf.ts
+++ b/src/isReallyThisTypeOf.ts
@@ -1,0 +1,65 @@
+import { TYPES } from "./types.ts";
+
+/**
+ * -------------------------------------------
+ *      isReallyThisTypeOf(value, type)
+ * -------------------------------------------
+ * 
+ * Autor: Gabriel (mas com a ajuda absurda do ChatGPT porque, né, tempo é dinheiro e paciência é luxo).
+ * 
+ * 🧠 Propósito:
+ * TypeScript é bonitinho na teoria, mas em tempo de execução ele tira férias. 
+ * Essa função resolve esse abandono parental e verifica se o valor é REALMENTE do tipo que ele diz ser.
+ * 
+ * Porque sim, meu querido, o TypeScript deixa tu passar `new String("abc")` como se fosse string,
+ * `NaN` como se fosse um number de verdade e até `undefined` escondido debaixo do tapete.
+ * 
+ * Então aqui a gente trata dado igual segurança de aeroporto: passou no scanner ou volta pro fim da fila.
+ * 
+ * @param {unknown} value - O bicho que você quer verificar.
+ * @param {TYPES} type - O tipo que ele diz ser (e que vamos verificar se é mesmo).
+ * @returns {boolean} true se for o tipo certo MESMO. false se for impostor.
+ * 
+ * @example
+ * isReallyThisTypeOf("Gabriel", TYPES.STRING); // true
+ * isReallyThisTypeOf(new String("Gabriel"), TYPES.STRING); // false, aqui não passa nem com reza
+ * isReallyThisTypeOf(42, TYPES.NUMBER); // true
+ * isReallyThisTypeOf(NaN, TYPES.NUMBER); // false, porque é um number com crise de identidade
+ */
+export function isReallyThisTypeOf(value: unknown, type: TYPES): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value !== type) return false;
+
+  switch (type) {
+    case TYPES.STRING:
+      return typeof value === 'string' &&
+             !(value as any instanceof String) &&
+             Object.prototype.toString.call(value) === '[object String]' &&
+             value.trim().length > 0;
+
+    case TYPES.NUMBER:
+      return typeof value === 'number' &&
+             !isNaN(value) &&
+             Number.isFinite(value);
+
+    case TYPES.BOOLEAN:
+      return typeof value === 'boolean';
+
+    case TYPES.FUNCTION:
+      return typeof value === 'function';
+
+    case TYPES.SYMBOL:
+      return typeof value === 'symbol';
+
+    case TYPES.BIGINT:
+      return typeof value === 'bigint';
+
+    case TYPES.OBJECT:
+      return typeof value === 'object' &&
+             !Array.isArray(value) &&
+             value !== null;
+
+    default:
+      return false;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Enum de tipos primitivos seguros para validação runtime.
+ * Compatível com `typeof` do JavaScript, mas usado de forma estrita.
+ * 
+ * Este enum deve ser usado com a função `isReallyThisTypeOf` para garantir
+ * que você está validando contra um tipo permitido e com regras específicas.
+ * 
+ * Obs: Se você tentar validar algo fora dessa lista, não será aceito (de propósito).
+ * 
+ * @readonly
+ * @enum {string}
+ * 
+ * @example
+ * import { TYPES } from "./types.ts";
+ * 
+ * const isNameValid = isReallyThisTypeOf("Gabriel", TYPES.STRING);
+ */
+export enum TYPES {
+  STRING = 'string',
+  NUMBER = 'number',
+  BOOLEAN = 'boolean',
+  OBJECT = 'object',
+  FUNCTION = 'function',
+  SYMBOL = 'symbol',
+  BIGINT = 'bigint',
+}

--- a/test/isReallyThisTypeOf.test.ts
+++ b/test/isReallyThisTypeOf.test.ts
@@ -1,0 +1,72 @@
+import {
+  isReallyThisTypeOf,
+  TYPES,
+} from "../mod.ts";
+import { assertEquals } from "https://deno.land/std@0.203.0/assert/mod.ts";
+
+// STRINGS
+Deno.test("STRING válida (primitiva)", () => {
+  assertEquals(isReallyThisTypeOf("Gabriel", TYPES.STRING), true);
+});
+
+Deno.test("STRING inválida (new String)", () => {
+  assertEquals(isReallyThisTypeOf(new String("Gabriel"), TYPES.STRING), false);
+});
+
+Deno.test("STRING inválida (vazia)", () => {
+  assertEquals(isReallyThisTypeOf("", TYPES.STRING), false);
+});
+
+Deno.test("STRING inválida (só espaços)", () => {
+  assertEquals(isReallyThisTypeOf("     ", TYPES.STRING), false);
+});
+
+// NUMBERS
+Deno.test("NUMBER válido", () => {
+  assertEquals(isReallyThisTypeOf(123, TYPES.NUMBER), true);
+});
+
+Deno.test("NUMBER inválido (NaN)", () => {
+  assertEquals(isReallyThisTypeOf(NaN, TYPES.NUMBER), false);
+});
+
+Deno.test("NUMBER inválido (Infinity)", () => {
+  assertEquals(isReallyThisTypeOf(Infinity, TYPES.NUMBER), false);
+});
+
+// BOOLEAN
+Deno.test("BOOLEAN verdadeiro", () => {
+  assertEquals(isReallyThisTypeOf(true, TYPES.BOOLEAN), true);
+});
+
+Deno.test("BOOLEAN falso", () => {
+  assertEquals(isReallyThisTypeOf(false, TYPES.BOOLEAN), true);
+});
+
+// OBJECT
+Deno.test("OBJECT válido", () => {
+  assertEquals(isReallyThisTypeOf({ nome: "Gabriel" }, TYPES.OBJECT), true);
+});
+
+Deno.test("OBJECT inválido (array)", () => {
+  assertEquals(isReallyThisTypeOf(["não"], TYPES.OBJECT), false);
+});
+
+Deno.test("OBJECT inválido (null)", () => {
+  assertEquals(isReallyThisTypeOf(null, TYPES.OBJECT), false);
+});
+
+// FUNCTION
+Deno.test("FUNCTION válida", () => {
+  assertEquals(isReallyThisTypeOf(() => {}, TYPES.FUNCTION), true);
+});
+
+// SYMBOL
+Deno.test("SYMBOL válido", () => {
+  assertEquals(isReallyThisTypeOf(Symbol("x"), TYPES.SYMBOL), true);
+});
+
+// BIGINT
+Deno.test("BIGINT válido", () => {
+  assertEquals(isReallyThisTypeOf(BigInt(10), TYPES.BIGINT), true);
+});


### PR DESCRIPTION
## Primeiro commit do `deno-sincerao`, uma proposta de validador de tipos reais em runtime pra projetos Deno e TypeScript.

Essa versão inclui:
> - Verificação rigorosa de tipos primitivos (`string`, `number`, `boolean`, etc.)
> - Enum `TYPES` para uso consistente
> - Testes cobrindo todos os tipos suportados
> - Documentação no estilo Gabriel™
> - Licença MIT (com um aviso sincero)

 ⚠️ Essa é a versão `0.1.0`, ainda sem testes de uso em projetos reais.  
>  Estou aberto a contribuições, melhorias, sugestões, correções de bug e até reclamações — desde que venham com PR.

